### PR TITLE
Fixing wrong WORKDIR syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:15.10
 
 
 RUN apt-get update \
-     && apt-get install -y python python-pip wget git apache2 ruby qemu-utils  apt-cacher-ng lxc  sudo debootstrap net-tools
+     && apt-get install -y python python-pip wget curl git apache2 ruby qemu-utils  apt-cacher-ng lxc  sudo debootstrap net-tools
 RUN mkdir /gitian \
      && cd /gitian \
      && wget http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr489.orig.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,5 @@ ENV LXC_GUEST_IP=10.0.3.5
 ENV MIRROR_HOST=127.0.0.1
 
 USER gitian
-WORKDIR ["/gitian"]
+WORKDIR /gitian
 ENTRYPOINT ["/gitian/make_gitian_vms.sh"]

--- a/Dockerfile.stage1
+++ b/Dockerfile.stage1
@@ -42,7 +42,7 @@ ENV LXC_GUEST_IP=10.0.3.5
 ENV MIRROR_HOST=127.0.0.1
 
 USER gitian
-WORKDIR ["/gitian"]
+WORKDIR /gitian
 
 
 ENTRYPOINT ["/gitian/make_gitian_vms.sh"]

--- a/Dockerfile.stage1
+++ b/Dockerfile.stage1
@@ -1,7 +1,7 @@
 FROM ubuntu:15.10
 
 RUN apt-get update \
-     && apt-get install -y python python-pip wget git apache2 ruby qemu-utils  apt-cacher-ng lxc  sudo debootstrap net-tools
+     && apt-get install -y python python-pip wget curl git apache2 ruby qemu-utils  apt-cacher-ng lxc  sudo debootstrap net-tools
 RUN mkdir /gitian \
      && cd /gitian \
      && wget http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr489.orig.tar.gz \

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -40,7 +40,7 @@ ENV LXC_GUEST_IP=10.0.3.5
 ENV MIRROR_HOST=127.0.0.1
 
 USER gitian
-WORKDIR ["/gitian"]
+WORKDIR /gitian
 
 
 ENTRYPOINT ["/gitian/make_gitian_vms.sh"]

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -2,7 +2,7 @@ FROM ubuntu:15.10
 
 
 RUN apt-get update \
-     && apt-get install -y python python-pip wget git apache2 ruby qemu-utils  apt-cacher-ng lxc  sudo debootstrap net-tools
+     && apt-get install -y python python-pip wget curl git apache2 ruby qemu-utils  apt-cacher-ng lxc  sudo debootstrap net-tools
 RUN mkdir /gitian \
      && cd /gitian \
      && wget http://archive.ubuntu.com/ubuntu/pool/universe/v/vm-builder/vm-builder_0.12.4+bzr489.orig.tar.gz \


### PR DESCRIPTION
According to https://docs.docker.com/engine/reference/builder/ the WORKDIR instruction uses the form

`WORKDIR /path/to/workdir`

so the brackets provided are causing a weird workdirectory name of

`gitian@196210e79d8f:/[/gitian]$`

inside the container. This fixes it..

Additionally the `make depends downloads` phase now relies on `curl` to be installed.
